### PR TITLE
fixed imports in cell 3. downgraded tensorflow to 1.13.1

### DIFF
--- a/2.0.1 - Reinforcement Learning - Keras DQN.ipynb
+++ b/2.0.1 - Reinforcement Learning - Keras DQN.ipynb
@@ -195,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -205,17 +205,75 @@
     "id": "3lOBizVa4rVt",
     "outputId": "a3142dd2-4ff0-4bb6-a833-a7046f4e0596"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "keras 2.3.1\n",
+      "Requirement already satisfied: tensorflow==1.13.1 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (1.13.1)\n",
+      "Requirement already satisfied: tensorflow-estimator<1.14.0rc0,>=1.13.0 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from tensorflow==1.13.1) (1.13.0)\n",
+      "Requirement already satisfied: numpy>=1.13.3 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from tensorflow==1.13.1) (1.17.4)\n",
+      "Requirement already satisfied: protobuf>=3.6.1 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from tensorflow==1.13.1) (3.11.1)\n",
+      "Requirement already satisfied: termcolor>=1.1.0 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from tensorflow==1.13.1) (1.1.0)\n",
+      "Requirement already satisfied: wheel>=0.26 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from tensorflow==1.13.1) (0.33.6)\n",
+      "Requirement already satisfied: grpcio>=1.8.6 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from tensorflow==1.13.1) (1.26.0)\n",
+      "Requirement already satisfied: gast>=0.2.0 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from tensorflow==1.13.1) (0.2.2)\n",
+      "Requirement already satisfied: absl-py>=0.1.6 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from tensorflow==1.13.1) (0.9.0)\n",
+      "Requirement already satisfied: six>=1.10.0 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from tensorflow==1.13.1) (1.13.0)\n",
+      "Requirement already satisfied: keras-applications>=1.0.6 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from tensorflow==1.13.1) (1.0.8)\n",
+      "Requirement already satisfied: keras-preprocessing>=1.0.5 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from tensorflow==1.13.1) (1.1.0)\n",
+      "Requirement already satisfied: tensorboard<1.14.0,>=1.13.0 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from tensorflow==1.13.1) (1.13.1)\n",
+      "Requirement already satisfied: astor>=0.6.0 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from tensorflow==1.13.1) (0.8.1)\n",
+      "Requirement already satisfied: mock>=2.0.0 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from tensorflow-estimator<1.14.0rc0,>=1.13.0->tensorflow==1.13.1) (4.0.1)\n",
+      "Requirement already satisfied: setuptools in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from protobuf>=3.6.1->tensorflow==1.13.1) (42.0.2)\n",
+      "Requirement already satisfied: h5py in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from keras-applications>=1.0.6->tensorflow==1.13.1) (2.10.0)\n",
+      "Requirement already satisfied: werkzeug>=0.11.15 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from tensorboard<1.14.0,>=1.13.0->tensorflow==1.13.1) (0.16.0)\n",
+      "Requirement already satisfied: markdown>=2.6.8 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from tensorboard<1.14.0,>=1.13.0->tensorflow==1.13.1) (3.1.1)\n",
+      "!!!! Please restart kernel to use tensorflow 1.13.1 !!!\n",
+      "tensorflow 1.13.1\n",
+      "Running! \n",
+      "Please dont interrupt this cell. It might cause serious issues..\n",
+      "Requirement already satisfied: gym in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (0.15.4)\n",
+      "Requirement already satisfied: keras-rl in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (0.4.2)\n",
+      "Requirement already satisfied: pyglet==1.2.4 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (1.2.4)\n",
+      "Requirement already satisfied: numpy>=1.10.4 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from gym) (1.17.4)\n",
+      "Requirement already satisfied: opencv-python in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from gym) (4.1.2.30)\n",
+      "Requirement already satisfied: six in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from gym) (1.13.0)\n",
+      "Requirement already satisfied: scipy in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from gym) (1.4.1)\n",
+      "Requirement already satisfied: cloudpickle~=1.2.0 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from gym) (1.2.1)\n",
+      "Requirement already satisfied: keras>=2.0.7 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from keras-rl) (2.3.1)\n",
+      "Requirement already satisfied: h5py in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from keras>=2.0.7->keras-rl) (2.10.0)\n",
+      "Requirement already satisfied: pyyaml in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from keras>=2.0.7->keras-rl) (5.3)\n",
+      "Requirement already satisfied: keras-applications>=1.0.6 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from keras>=2.0.7->keras-rl) (1.0.8)\n",
+      "Requirement already satisfied: keras-preprocessing>=1.0.5 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from keras>=2.0.7->keras-rl) (1.1.0)\n",
+      "Requirement already satisfied: gym[atari] in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (0.15.4)\n",
+      "Requirement already satisfied: six in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from gym[atari]) (1.13.0)\n",
+      "Requirement already satisfied: pyglet<=1.3.2,>=1.2.0 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from gym[atari]) (1.2.4)\n",
+      "Requirement already satisfied: cloudpickle~=1.2.0 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from gym[atari]) (1.2.1)\n",
+      "Requirement already satisfied: numpy>=1.10.4 in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from gym[atari]) (1.17.4)\n",
+      "Requirement already satisfied: scipy in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from gym[atari]) (1.4.1)\n",
+      "Requirement already satisfied: opencv-python in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from gym[atari]) (4.1.2.30)\n",
+      "Requirement already satisfied: atari-py~=0.2.0; extra == \"atari\" in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from gym[atari]) (0.2.6)\n",
+      "Requirement already satisfied: Pillow; extra == \"atari\" in /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages (from gym[atari]) (6.2.1)\n",
+      "Done!\n"
+     ]
+    }
+   ],
    "source": [
     "import keras\n",
-    "keras.__version__\n",
+    "print('keras', keras.__version__)\n",
+    "!pip install 'tensorflow==1.13.1'  # see https://github.com/keras-rl/keras-rl/issues/348#issuecomment-568241076\n",
+    "print(\"!!!! Please restart kernel to use tensorflow 1.13.1 !!!\")\n",
+    "import tensorflow\n",
+    "print('tensorflow', tensorflow.__version__)\n",
     "from tensorflow.python.client import device_lib\n",
     "device_lib.list_local_devices()\n",
-    "print 'Running! \\nPlease dont interrupt this cell. It might cause serious issues..'\n",
+    "print('Running! \\nPlease dont interrupt this cell. It might cause serious issues..')\n",
     "!pip install gym keras-rl pyglet==1.2.4 \n",
     "# !apt-get install -y cmake zlib1g-dev libjpeg-dev xvfb ffmpeg xorg-dev python-opengl libboost-all-dev libsdl2-dev swig \n",
     "!pip install 'gym[atari]' \n",
-    "print 'Done!'"
+    "print('Done!')"
    ]
   },
   {
@@ -254,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,8 +323,8 @@
     "from IPython import display\n",
     "from PIL import Image\n",
     "\n",
-    "from keras.models import Sequential\n",
-    "from keras.layers import Dense, Activation, Flatten, Convolution2D, Permute\n",
+    "from keras.models import Sequential, Model\n",
+    "from keras.layers import Input, Dense, Activation, Flatten, Convolution2D, Permute\n",
     "from keras.optimizers import Adam\n",
     "\n",
     "from rl.callbacks import Callback\n",
@@ -286,7 +344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -358,35 +416,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "WARNING:tensorflow:From /home/eli/workspace/robotlab/rlenv/lib/python3.6/site-packages/tensorflow/python/ops/resource_variable_ops.py:435: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Colocations handled automatically by placer.\n",
+      "Model: \"model_1\"\n",
       "_________________________________________________________________\n",
       "Layer (type)                 Output Shape              Param #   \n",
       "=================================================================\n",
-      "input_2 (InputLayer)         (None, 1, 4)              0         \n",
+      "input_1 (InputLayer)         (None, 1, 4)              0         \n",
       "_________________________________________________________________\n",
-      "flatten_2 (Flatten)          (None, 4)                 0         \n",
+      "flatten_1 (Flatten)          (None, 4)                 0         \n",
       "_________________________________________________________________\n",
-      "dense_7 (Dense)              (None, 16)                80        \n",
+      "dense_1 (Dense)              (None, 16)                80        \n",
       "_________________________________________________________________\n",
-      "activation_5 (Activation)    (None, 16)                0         \n",
+      "activation_1 (Activation)    (None, 16)                0         \n",
       "_________________________________________________________________\n",
-      "dense_8 (Dense)              (None, 16)                272       \n",
+      "dense_2 (Dense)              (None, 16)                272       \n",
       "_________________________________________________________________\n",
-      "activation_6 (Activation)    (None, 16)                0         \n",
+      "activation_2 (Activation)    (None, 16)                0         \n",
       "_________________________________________________________________\n",
-      "dense_9 (Dense)              (None, 16)                272       \n",
+      "dense_3 (Dense)              (None, 16)                272       \n",
       "_________________________________________________________________\n",
-      "activation_7 (Activation)    (None, 16)                0         \n",
+      "activation_3 (Activation)    (None, 16)                0         \n",
       "_________________________________________________________________\n",
-      "dense_10 (Dense)             (None, 2)                 34        \n",
+      "dense_4 (Dense)              (None, 2)                 34        \n",
       "_________________________________________________________________\n",
-      "activation_8 (Activation)    (None, 2)                 0         \n",
+      "activation_4 (Activation)    (None, 2)                 0         \n",
       "=================================================================\n",
       "Total params: 658\n",
       "Trainable params: 658\n",
@@ -420,7 +482,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +492,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,7 +504,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -463,7 +525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,29 +548,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   72/10000 [..............................] - ETA: 26:53 - reward: 1.0000done, took 11.757 seconds\n"
+      "  100/10000 [..............................] - ETA: 36:08 - reward: 1.0000done, took 21.904 seconds\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<keras.callbacks.History at 0x7fc3c0301850>"
+       "<keras.callbacks.callbacks.History at 0x7f600033d240>"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXgAAAD8CAYAAAB9y7/cAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAEllJREFUeJzt3XGMnVd95vHvs3ZIKLB1QqaWazvrtPUuSqviZGdDIlCVJqJNsts6lVqUtCoRijSsFCRQ0W6TrrQlUiO1UktatLtR3SZgKpaQDdC4UVqamkgVf5AwAWPsmJQBjGyvEw+QBFi02XX49Y85htth7Lkzd67Hc/r9SFf3fc973nt/J7l65vWZ98xNVSFJ6s+/WO0CJEnjYcBLUqcMeEnqlAEvSZ0y4CWpUwa8JHVqbAGf5PokzySZSXLHuN5HkrSwjOM++CTrgH8A3gwcBT4D3FJVT6/4m0mSFjSuK/grgZmq+kpV/T/gAWDnmN5LkrSA9WN63c3AkYH9o8AbTtf54osvrm3bto2pFElaew4fPszXv/71jPIa4wr4RSWZAqYALrnkEqanp1erFEk650xOTo78GuOaojkGbB3Y39Lavq+qdlXVZFVNTkxMjKkMSfrna1wB/xlge5JLk7wCuBnYM6b3kiQtYCxTNFV1Msk7gE8A64D7q+rgON5LkrSwsc3BV9WjwKPjen1J0pm5klWSOmXAS1KnDHhJ6pQBL0mdMuAlqVMGvCR1yoCXpE4Z8JLUKQNekjplwEtSpwx4SeqUAS9JnTLgJalTBrwkdcqAl6ROGfCS1CkDXpI6ZcBLUqdG+sq+JIeBbwMvAyerajLJRcBHgG3AYeAtVfX8aGVKkpZqJa7gf76qdlTVZNu/A9hbVduBvW1fknSWjWOKZiewu23vBm4aw3tIkhYxasAX8LdJnkoy1do2VtXxtv0ssHHE95AkLcNIc/DAm6rqWJIfAx5L8sXBg1VVSWqhE9sPhCmASy65ZMQyJEnzjXQFX1XH2vMJ4OPAlcBzSTYBtOcTpzl3V1VNVtXkxMTEKGVIkhaw7IBP8qokrzm1DfwCcADYA9zaut0KPDxqkZKkpRtlimYj8PEkp17nf1bV3yT5DPBgktuArwFvGb1MSdJSLTvgq+orwOsXaP8GcN0oRUmSRudKVknqlAEvSZ0y4CWpUwa8JHXKgJekThnwktQpA16SOmXAS1KnDHhJ6pQBL0mdMuAlqVMGvCR1yoCXpE4Z8JLUKQNekjplwEtSpwx4SeqUAS9JnTLgJalTiwZ8kvuTnEhyYKDtoiSPJflSe76wtSfJ+5LMJNmf5IpxFi9JOr1hruA/AFw/r+0OYG9VbQf2tn2AG4Dt7TEF3LsyZUqSlmrRgK+qvwe+Oa95J7C7be8Gbhpo/2DN+TSwIcmmlSpWkjS85c7Bb6yq4237WWBj294MHBnod7S1/ZAkU0mmk0zPzs4uswxJ0umM/EvWqiqglnHerqqarKrJiYmJUcuQJM2z3IB/7tTUS3s+0dqPAVsH+m1pbZKks2y5Ab8HuLVt3wo8PND+1nY3zVXAiwNTOZKks2j9Yh2SfBi4Brg4yVHgd4HfBx5MchvwNeAtrfujwI3ADPBd4G1jqFmSNIRFA76qbjnNoesW6FvA7aMWJUkanStZJalTBrwkdcqAl6ROGfCS1CkDXpI6ZcBLUqcMeEnqlAEvSZ0y4CWpUwa8JHXKgJekThnwktQpA16SOmXAS1KnDHhJ6pQBL0mdMuAlqVMGvCR1atGAT3J/khNJDgy0vSfJsST72uPGgWN3JplJ8kySXxxX4ZKkMxvmCv4DwPULtN9TVTva41GAJJcBNwM/3c75H0nWrVSxkqThLRrwVfX3wDeHfL2dwANV9VJVfRWYAa4coT5J0jKNMgf/jiT72xTOha1tM3BkoM/R1vZDkkwlmU4yPTs7O0IZkqSFLDfg7wV+EtgBHAf+aKkvUFW7qmqyqiYnJiaWWYYk6XSWFfBV9VxVvVxV3wP+jB9MwxwDtg503dLaJEln2bICPsmmgd1fAU7dYbMHuDnJ+UkuBbYDT45WoiRpOdYv1iHJh4FrgIuTHAV+F7gmyQ6ggMPA2wGq6mCSB4GngZPA7VX18nhKlySdyaIBX1W3LNB83xn63w3cPUpRkqTRuZJVkjplwEtSpwx4SeqUAS9JnTLgJalTBrwkdWrR2ySlf+6e2vX2Bdv/7dSfnuVKpKXxCl5ahEGutcqAl6ROGfCS1CkDXpI6ZcBLUqcMeEnqlAEvSZ0y4KVlOt398dK5woCXpE4Z8JLUKQNekjq1aMAn2Zrk8SRPJzmY5J2t/aIkjyX5Unu+sLUnyfuSzCTZn+SKcQ9CkvTDhrmCPwm8u6ouA64Cbk9yGXAHsLeqtgN72z7ADcD29pgC7l3xqiVJi1o04KvqeFV9tm1/GzgEbAZ2Artbt93ATW17J/DBmvNpYEOSTSteuSTpjJY0B59kG3A58ASwsaqOt0PPAhvb9mbgyMBpR1vb/NeaSjKdZHp2dnaJZUuSFjN0wCd5NfBR4F1V9a3BY1VVQC3ljatqV1VNVtXkxMTEUk6Vzjr/ZLDWoqECPsl5zIX7h6rqY635uVNTL+35RGs/BmwdOH1La5MknUXD3EUT4D7gUFW9d+DQHuDWtn0r8PBA+1vb3TRXAS8OTOVIks6SYb6y743AbwJfSLKvtf0O8PvAg0luA74GvKUdexS4EZgBvgu8bUUrliQNZdGAr6pPATnN4esW6F/A7SPWJUkakStZJalTBrwkdcqAl4a00K2S/slgncsMeEnqlAEvSZ0y4CWpUwa8JHXKgJekThnwktQpA14akbdK6lxlwEtSpwx4SeqUAS9JnTLgJalTBrwkdcqAl6ROGfDSEvjl21pLDHhJ6tQwX7q9NcnjSZ5OcjDJO1v7e5IcS7KvPW4cOOfOJDNJnknyi+McgCRpYcN86fZJ4N1V9dkkrwGeSvJYO3ZPVf3hYOcklwE3Az8N/Djwd0n+dVW9vJKFS5LObNEr+Ko6XlWfbdvfBg4Bm89wyk7ggap6qaq+CswAV65EsZKk4S1pDj7JNuBy4InW9I4k+5Pcn+TC1rYZODJw2lHO/ANBkjQGQwd8klcDHwXeVVXfAu4FfhLYARwH/mgpb5xkKsl0kunZ2dmlnCpJGsJQAZ/kPObC/UNV9TGAqnquql6uqu8Bf8YPpmGOAVsHTt/S2v6JqtpVVZNVNTkxMTHKGKRV51+U1LlomLtoAtwHHKqq9w60bxro9ivAgba9B7g5yflJLgW2A0+uXMmSpGEMcxfNG4HfBL6QZF9r+x3gliQ7gAIOA28HqKqDSR4EnmbuDpzbvYNGks6+RQO+qj4FZIFDj57hnLuBu0eoS5I0IleySlKnDHhJ6pQBL0mdMuAlqVMGvLRE/slgrRUGvCR1yoCXpE4Z8JLUKQNekjplwEtSpwx4SeqUAS+tEP9ksM41BrwkdcqAl5okQz/G+RrSSjHgJalTw3zhh6QF/NX/nvon+7/047tWqRJpYV7BSytkfuBLq82Al5bBMNdaMMyXbl+Q5Mkkn09yMMldrf3SJE8kmUnykSSvaO3nt/2ZdnzbeIcgnX133TW52iVIixrmCv4l4Nqqej2wA7g+yVXAHwD3VNVPAc8Dt7X+twHPt/Z7Wj+pe87B61wzzJduF/CdtnteexRwLfDrrX038B7gXmBn2wZ4CPhvSdJeR+rG/Kv4u1apDul0hpqDT7IuyT7gBPAY8GXghao62bocBTa37c3AEYB2/EXgtStZtCRpcUMFfFW9XFU7gC3AlcDrRn3jJFNJppNMz87OjvpykqR5lnQXTVW9ADwOXA1sSHJqimcLcKxtHwO2ArTjPwp8Y4HX2lVVk1U1OTExsczyJUmnM8xdNBNJNrTtVwJvBg4xF/S/2rrdCjzctve0fdrxTzr/Lkln3zArWTcBu5OsY+4HwoNV9UiSp4EHkvwe8Dngvtb/PuAvkswA3wRuHkPdkqRFDHMXzX7g8gXav8LcfPz89v8L/NqKVCdJWjZXskpSpwx4SeqUAS9JnfLPBUuNN3upN17BS1KnDHhJ6pQBL0mdMuAlqVMGvCR1yoCXpE4Z8JLUKQNekjplwEtSpwx4SeqUAS9JnTLgJalTBrwkdcqAl6RODfOl2xckeTLJ55McTHJXa/9Akq8m2dceO1p7krwvyUyS/UmuGPcgJEk/bJi/B/8ScG1VfSfJecCnkvx1O/afquqhef1vALa3xxuAe9uzJOksWvQKvuZ8p+2e1x5n+maEncAH23mfBjYk2TR6qZKkpRhqDj7JuiT7gBPAY1X1RDt0d5uGuSfJ+a1tM3Bk4PSjrU2SdBYNFfBV9XJV7QC2AFcm+RngTuB1wL8DLgJ+eylvnGQqyXSS6dnZ2SWWLUlazJLuoqmqF4DHgeur6nibhnkJeD9wZet2DNg6cNqW1jb/tXZV1WRVTU5MTCyveknSaQ1zF81Ekg1t+5XAm4EvnppXTxLgJuBAO2UP8NZ2N81VwItVdXws1UuSTmuYu2g2AbuTrGPuB8KDVfVIkk8mmQAC7AP+Y+v/KHAjMAN8F3jbypctSVrMogFfVfuByxdov/Y0/Qu4ffTSJEmjcCWrJHXKgJekThnwktQpA16SOmXAS1KnDHhJ6pQBL0mdMuAlqVMGvCR1yoCXpE4Z8JLUKQNekjplwEtSpwx4SeqUAS9JnTLgJalTBrwkdcqAl6ROGfCS1KmhAz7JuiSfS/JI2780yRNJZpJ8JMkrWvv5bX+mHd82ntIlSWeylCv4dwKHBvb/ALinqn4KeB64rbXfBjzf2u9p/SRJZ9lQAZ9kC/DvgT9v+wGuBR5qXXYDN7XtnW2fdvy61l+SdBatH7LfHwP/GXhN238t8EJVnWz7R4HNbXszcASgqk4mebH1//rgCyaZAqba7ktJDixrBOe+i5k39k70Oi7od2yOa235V0mmqmrXcl9g0YBP8h+AE1X1VJJrlvtG87Wid7X3mK6qyZV67XNJr2PrdVzQ79gc19qTZJqWk8sxzBX8G4FfTnIjcAHwL4E/ATYkWd+u4rcAx1r/Y8BW4GiS9cCPAt9YboGSpOVZdA6+qu6sqi1VtQ24GfhkVf0G8Djwq63brcDDbXtP26cd/2RV1YpWLUla1Cj3wf828FtJZpibY7+vtd8HvLa1/xZwxxCvtex/gqwBvY6t13FBv2NzXGvPSGOLF9eS1CdXskpSp1Y94JNcn+SZtvJ1mOmcc0qS+5OcGLzNM8lFSR5L8qX2fGFrT5L3tbHuT3LF6lV+Zkm2Jnk8ydNJDiZ5Z2tf02NLckGSJ5N8vo3rrtbexcrsXlecJzmc5AtJ9rU7S9b8ZxEgyYYkDyX5YpJDSa5eyXGtasAnWQf8d+AG4DLgliSXrWZNy/AB4Pp5bXcAe6tqO7CXH/we4gZge3tMAfeepRqX4yTw7qq6DLgKuL39v1nrY3sJuLaqXg/sAK5PchX9rMzuecX5z1fVjoFbItf6ZxHm7kj8m6p6HfB65v7frdy4qmrVHsDVwCcG9u8E7lzNmpY5jm3AgYH9Z4BNbXsT8Ezb/lPgloX6nesP5u6SenNPYwN+BPgs8AbmFsqsb+3f/1wCnwCubtvrW7+sdu2nGc+WFgjXAo8A6WFcrcbDwMXz2tb0Z5G5W8i/Ov+/+0qOa7WnaL6/6rUZXBG7lm2squNt+1lgY9tek+Nt/3y/HHiCDsbWpjH2ASeAx4AvM+TKbODUyuxz0akV599r+0OvOOfcHhdAAX+b5Km2Ch7W/mfxUmAWeH+bVvvzJK9iBce12gHfvZr7Ubtmb1VK8mrgo8C7qupbg8fW6tiq6uWq2sHcFe+VwOtWuaSRZWDF+WrXMiZvqqormJumuD3Jzw0eXKOfxfXAFcC9VXU58H+Yd1v5qONa7YA/ter1lMEVsWvZc0k2AbTnE619TY03yXnMhfuHqupjrbmLsQFU1QvMLdi7mrYyux1aaGU25/jK7FMrzg8DDzA3TfP9Feetz1ocFwBVdaw9nwA+ztwP5rX+WTwKHK2qJ9r+Q8wF/oqNa7UD/jPA9vab/lcwt1J2zyrXtBIGV/POX+X71vbb8KuAFwf+KXZOSRLmFq0dqqr3Dhxa02NLMpFkQ9t+JXO/VzjEGl+ZXR2vOE/yqiSvObUN/AJwgDX+WayqZ4EjSf5Na7oOeJqVHNc58IuGG4F/YG4e9L+sdj3LqP/DwHHg/zP3E/k25uYy9wJfAv4OuKj1DXN3DX0Z+AIwudr1n2Fcb2Lun4b7gX3tceNaHxvws8Dn2rgOAP+1tf8E8CQwA/wv4PzWfkHbn2nHf2K1xzDEGK8BHullXG0Mn2+Pg6dyYq1/FlutO4Dp9nn8S+DClRyXK1klqVOrPUUjSRoTA16SOmXAS1KnDHhJ6pQBL0mdMuAlqVMGvCR1yoCXpE79I1ROheW9h5AaAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAW4AAAD8CAYAAABXe05zAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAARQklEQVR4nO3dcYycd33n8fenTgi0oCYhW8u1nTotPqH0dDh0G4LgjzSINkSophKHkjsVC0VaTgoSSOjuklZqQWqkVrqSO3RthKukmIoS0gKKFeUOXBOp4g8SNmCMnZCygFFsmXiBJIBQ0yZ8+8f+HKbOOju7s5Pxb+f9kkbzPN/n98x8f8rkkyc/P+NJVSFJ6sfPTboBSdLqGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0ZW3AnuTbJo0kWktw8rveRpGmTcdzHnWQT8E/Am4HjwJeAG6rq4XV/M0maMuO64r4SWKiqb1XVvwB3AbvH9F6SNFXOG9PrbgUeG9g/DrzubIMvueSS2rFjx5hakaT+HDt2jO9973tZ7ti4gntFSeaAOYBLL72U+fn5SbUiSeec2dnZsx4b11LJCWD7wP62VntOVe2tqtmqmp2ZmRlTG5K08YwruL8E7ExyWZKXANcD+8f0XpI0VcayVFJVzyR5D/BZYBNwZ1UdHcd7SdK0Gdsad1XdB9w3rteXpGnlNyclqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHVmpJ8uS3IM+BHwLPBMVc0muRj4JLADOAa8o6qeGK1NSdJp63HF/VtVtauqZtv+zcDBqtoJHGz7kqR1Mo6lkt3Avra9D3jbGN5DkqbWqMFdwOeSPJRkrtU2V9XJtv1dYPOI7yFJGjDSGjfwxqo6keSXgANJvj54sKoqSS13Ygv6OYBLL710xDYkaXqMdMVdVSfa8yngM8CVwONJtgC051NnOXdvVc1W1ezMzMwobUjSVFlzcCf5hSSvOL0N/DZwBNgP7GnD9gD3jNqkJOlnRlkq2Qx8Jsnp1/nbqvr/Sb4E3J3kRuA7wDtGb1OSdNqag7uqvgW8Zpn694E3jdKUJOns/OakJHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1JkVgzvJnUlOJTkyULs4yYEk32jPF7V6knw4yUKSw0leO87mJWkaDXPF/VHg2jNqNwMHq2oncLDtA7wF2Nkec8Dt69OmJOm0FYO7qv4R+MEZ5d3Avra9D3jbQP1jteSLwIVJtqxXs5Kkta9xb66qk237u8Dmtr0VeGxg3PFWe54kc0nmk8wvLi6usQ1Jmj4j/+FkVRVQazhvb1XNVtXszMzMqG1I0tRYa3A/fnoJpD2favUTwPaBcdtaTZK0TtYa3PuBPW17D3DPQP2d7e6Sq4CnBpZUJEnr4LyVBiT5BHA1cEmS48AfA38K3J3kRuA7wDva8PuA64AF4CfAu8bQsyRNtRWDu6puOMuhNy0ztoCbRm1KknR2fnNSkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnVgzuJHcmOZXkyEDtA0lOJDnUHtcNHLslyUKSR5P8zrgal6RpNcwV90eBa5ep31ZVu9rjPoAklwPXA7/ezvnLJJvWq1lJ0hDBXVX/CPxgyNfbDdxVVU9X1bdZ+rX3K0foT5J0hlHWuN+T5HBbSrmo1bYCjw2MOd5qz5NkLsl8kvnFxcUR2pCk6bLW4L4d+DVgF3AS+PPVvkBV7a2q2aqanZmZWWMbkjR91hTcVfV4VT1bVT8F/oqfLYecALYPDN3WapKkdbKm4E6yZWD394DTd5zsB65PckGSy4CdwIOjtShJGnTeSgOSfAK4GrgkyXHgj4Grk+wCCjgGvBugqo4muRt4GHgGuKmqnh1P65I0nVYM7qq6YZnyHS8w/lbg1lGakiSdnd+clKTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ1Z8XZAaRo9tPfdz6v9xtxHJtCJ9HxecUtSZwxuSeqMwS1JnTG4JakzBrckdcbgloa03J0m0iQY3JLUGYNbkjpjcEtSZwxuSeqMwS1JnVkxuJNsT3J/koeTHE3y3la/OMmBJN9ozxe1epJ8OMlCksNJXjvuSUjSNBnmivsZ4P1VdTlwFXBTksuBm4GDVbUTONj2Ad7C0q+77wTmgNvXvWtJmmIrBndVnayqL7ftHwGPAFuB3cC+Nmwf8La2vRv4WC35InBhki3r3rkkTalVrXEn2QFcATwAbK6qk+3Qd4HNbXsr8NjAacdb7czXmksyn2R+cXFxlW1L0vQaOriTvBz4FPC+qvrh4LGqKqBW88ZVtbeqZqtqdmZmZjWnStJUGyq4k5zPUmh/vKo+3cqPn14Cac+nWv0EsH3g9G2tJklaB8PcVRLgDuCRqvrQwKH9wJ62vQe4Z6D+znZ3yVXAUwNLKpKkEQ3z02VvAH4f+FqSQ632B8CfAncnuRH4DvCOduw+4DpgAfgJ8K517ViSptyKwV1VXwBylsNvWmZ8ATeN2Jck6Sz85qQkdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLS3jN+Y+MukWpLMyuCWpMwa3JHXG4JakzgzzY8Hbk9yf5OEkR5O8t9U/kOREkkPtcd3AObckWUjyaJLfGecEJGnaDPNjwc8A76+qLyd5BfBQkgPt2G1V9b8GBye5HLge+HXgl4F/SPIfqurZ9WxckqbVilfcVXWyqr7ctn8EPAJsfYFTdgN3VdXTVfVtln7t/cr1aFaStMo17iQ7gCuAB1rpPUkOJ7kzyUWtthV4bOC047xw0EuSVmHo4E7ycuBTwPuq6ofA7cCvAbuAk8Cfr+aNk8wlmU8yv7i4uJpTJWmqDRXcSc5nKbQ/XlWfBqiqx6vq2ar6KfBX/Gw55ASwfeD0ba3271TV3qqararZmZmZUeYgSVNlmLtKAtwBPFJVHxqobxkY9nvAkba9H7g+yQVJLgN2Ag+uX8uSNN2GuavkDcDvA19LcqjV/gC4IckuoIBjwLsBqupokruBh1m6I+Um7yiRpPWzYnBX1ReALHPovhc451bg1hH6kiSdhd+clKTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBramSZOjHqOef7TWkURncktSZYX5IQZpa956cO6OydyJ9SIO84pbO4vmhDfMfeX5NerEZ3NIqLBfm0ottmB8LfmmSB5N8NcnRJB9s9cuSPJBkIcknk7yk1S9o+wvt+I7xTkF68bx1i0slmrxhrrifBq6pqtcAu4Brk1wF/BlwW1W9CngCuLGNvxF4otVva+Ok7hjSOlcN82PBBfy47Z7fHgVcA/yXVt8HfAC4HdjdtgH+Hvi/SdJeR+rG7Lv3cuYfRn5gIp1I/95Qa9xJNiU5BJwCDgDfBJ6sqmfakOPA1ra9FXgMoB1/CnjlejYtSdNsqOCuqmerahewDbgSePWob5xkLsl8kvnFxcVRX06Spsaq7iqpqieB+4HXAxcmOb3Usg040bZPANsB2vFfBL6/zGvtrarZqpqdmZlZY/uSNH2GuatkJsmFbftlwJuBR1gK8Le3YXuAe9r2/rZPO/5517claf0M883JLcC+JJtYCvq7q+reJA8DdyX5E+ArwB1t/B3A3yRZAH4AXD+GviVpag1zV8lh4Ipl6t9iab37zPo/A/95XbqTJD2P35yUpM4Y3JLUGYNbkjrjX+uqqeINTtoIvOKWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0Z5seCX5rkwSRfTXI0yQdb/aNJvp3kUHvsavUk+XCShSSHk7x23JOQpGkyzN/H/TRwTVX9OMn5wBeS/L927L9X1d+fMf4twM72eB1we3uWJK2DFa+4a8mP2+757fFCfxv9buBj7bwvAhcm2TJ6q5IkGHKNO8mmJIeAU8CBqnqgHbq1LYfcluSCVtsKPDZw+vFWkyStg6GCu6qerapdwDbgyiT/EbgFeDXwm8DFwP9czRsnmUsyn2R+cXFxlW1L0vRa1V0lVfUkcD9wbVWdbMshTwN/DVzZhp0Atg+ctq3VznytvVU1W1WzMzMza+tekqbQMHeVzCS5sG2/DHgz8PXT69ZJArwNONJO2Q+8s91dchXwVFWdHEv3kjSFhrmrZAuwL8kmloL+7qq6N8nnk8wAAQ4B/62Nvw+4DlgAfgK8a/3blqTptWJwV9Vh4Ipl6tecZXwBN43emiRpOX5zUpI6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdSZVNekeSPIj4NFJ9zEmlwDfm3QTY7BR5wUbd27Oqy+/UlUzyx0478Xu5CwerarZSTcxDknmN+LcNuq8YOPOzXltHC6VSFJnDG5J6sy5Etx7J93AGG3UuW3UecHGnZvz2iDOiT+clCQN71y54pYkDWniwZ3k2iSPJllIcvOk+1mtJHcmOZXkyEDt4iQHknyjPV/U6kny4TbXw0leO7nOX1iS7UnuT/JwkqNJ3tvqXc8tyUuTPJjkq21eH2z1y5I80Pr/ZJKXtPoFbX+hHd8xyf5XkmRTkq8kubftb5R5HUvytSSHksy3WtefxVFMNLiTbAL+AngLcDlwQ5LLJ9nTGnwUuPaM2s3AwaraCRxs+7A0z53tMQfc/iL1uBbPAO+vqsuBq4Cb2j+b3uf2NHBNVb0G2AVcm+Qq4M+A26rqVcATwI1t/I3AE61+Wxt3Lnsv8MjA/kaZF8BvVdWugVv/ev8srl1VTewBvB747MD+LcAtk+xpjfPYARwZ2H8U2NK2t7B0nzrAR4Ablht3rj+Ae4A3b6S5AT8PfBl4HUtf4Div1Z/7XAKfBV7fts9r4zLp3s8yn20sBdg1wL1ANsK8Wo/HgEvOqG2Yz+JqH5NeKtkKPDawf7zVere5qk627e8Cm9t2l/Nt/xt9BfAAG2BubTnhEHAKOAB8E3iyqp5pQwZ7f25e7fhTwCtf3I6H9r+B/wH8tO2/ko0xL4ACPpfkoSRzrdb9Z3GtzpVvTm5YVVVJur11J8nLgU8B76uqHyZ57livc6uqZ4FdSS4EPgO8esItjSzJW4FTVfVQkqsn3c8YvLGqTiT5JeBAkq8PHuz1s7hWk77iPgFsH9jf1mq9ezzJFoD2fKrVu5pvkvNZCu2PV9WnW3lDzA2gqp4E7mdpCeHCJKcvZAZ7f25e7fgvAt9/kVsdxhuA301yDLiLpeWS/0P/8wKgqk6051Ms/cf2SjbQZ3G1Jh3cXwJ2tj/5fglwPbB/wj2th/3Anra9h6X14dP1d7Y/9b4KeGrgf/XOKVm6tL4DeKSqPjRwqOu5JZlpV9okeRlL6/aPsBTgb2/DzpzX6fm+Hfh8tYXTc0lV3VJV26pqB0v/Hn2+qv4rnc8LIMkvJHnF6W3gt4EjdP5ZHMmkF9mB64B/Ymmd8Q8n3c8a+v8EcBL4V5bW0m5kaa3wIPAN4B+Ai9vYsHQXzTeBrwGzk+7/Beb1RpbWFQ8Dh9rjut7nBvwn4CttXkeAP2r1XwUeBBaAvwMuaPWXtv2FdvxXJz2HIeZ4NXDvRplXm8NX2+Po6Zzo/bM4ysNvTkpSZya9VCJJWiWDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4Jakzvwb+g3qQRzpwdwAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -550,7 +612,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -566,9 +628,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Episode 5: reward: 9.000, steps: 9\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<keras.callbacks.callbacks.History at 0x7f5f630ffba8>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAW4AAAD8CAYAAABXe05zAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAARj0lEQVR4nO3dcYxdZ3nn8e+vTghsQU1CppZrO3VavELpqjjsNATBH2kQbYhQTSUWJbsqFopkKgUJJLS7SVdqg9RIrbQlu2jbqK6SYipKSAsoVpQuuCZSxR8kTMAYOyFlAKPYMvEASQChpk14+se8DhczztyZOzd33rnfj3R0z3nOOfc+r3Lzy8l7z52bqkKS1I+fm3QDkqSVMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjoztuBOcm2Sx5LMJ7l5XK8jSdMm47iPO8km4J+BNwMngC8AN1TVI2v+YpI0ZcZ1xX0lMF9V36iqfwXuBnaP6bUkaaqcN6bn3Qo8PrB9AnjduQ6+5JJLaseOHWNqRZL6c/z4cb7zne9kqX3jCu5lJdkL7AW49NJLmZubm1QrkrTuzM7OnnPfuKZKTgLbB7a3tdrzqmpfVc1W1ezMzMyY2pCkjWdcwf0FYGeSy5K8BLgeODCm15KkqTKWqZKqejbJe4BPA5uAu6rq2DheS5KmzdjmuKvqfuD+cT2/JE0rvzkpSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzI/10WZLjwA+A54Bnq2o2ycXAx4EdwHHgHVX15GhtSpLOWIsr7t+sql1VNdu2bwYOVdVO4FDbliStkXFMlewG9rf1/cDbxvAakjS1Rg3uAj6T5OEke1ttc1WdauvfBjaP+BqSpAEjzXEDb6yqk0l+ETiY5KuDO6uqktRSJ7ag3wtw6aWXjtiGJE2Pka64q+pkezwNfAq4EngiyRaA9nj6HOfuq6rZqpqdmZkZpQ1JmiqrDu4kP5/kFWfWgd8CjgIHgD3tsD3AvaM2KUn6iVGmSjYDn0py5nn+tqr+f5IvAPckuRH4FvCO0duUJJ2x6uCuqm8Ar1mi/l3gTaM0JUk6N785KUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHVm2eBOcleS00mODtQuTnIwydfa40WtniQfSjKf5EiS146zeUmaRsNccX8YuPas2s3AoaraCRxq2wBvAXa2ZS9wx9q0KUk6Y9ngrqp/Ar53Vnk3sL+t7wfeNlD/SC36PHBhki1r1awkafVz3Jur6lRb/zawua1vBR4fOO5Eq/2MJHuTzCWZW1hYWGUbkjR9Rv5wsqoKqFWct6+qZqtqdmZmZtQ2JGlqrDa4nzgzBdIeT7f6SWD7wHHbWk2StEZWG9wHgD1tfQ9w70D9ne3ukquApwemVCRJa+C85Q5I8jHgauCSJCeAPwL+BLgnyY3At4B3tMPvB64D5oEfAe8aQ8+SNNWWDe6quuEcu960xLEF3DRqU5Kkc/Obk5LUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOrNscCe5K8npJEcHarcmOZnkcFuuG9h3S5L5JI8l+e1xNS5J02qYK+4PA9cuUb+9qna15X6AJJcD1wO/1s75iySb1qpZSdIQwV1V/wR8b8jn2w3cXVXPVNU3Wfy19ytH6E+SdJZR5rjfk+RIm0q5qNW2Ao8PHHOi1X5Gkr1J5pLMLSwsjNCGJE2X1Qb3HcCvAruAU8CfrfQJqmpfVc1W1ezMzMwq25Ck6bOq4K6qJ6rquar6MfBX/GQ65CSwfeDQba0mSVojqwruJFsGNn8XOHPHyQHg+iQXJLkM2Ak8NFqLkqRB5y13QJKPAVcDlyQ5AfwRcHWSXUABx4F3A1TVsST3AI8AzwI3VdVz42ldkqbTssFdVTcsUb7zBY6/DbhtlKYkSefmNyclqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSerMsvdxS9Ps4X3v/qnt/7z3LyfUifQTXnFLK3B2kEuTYHBLUmcMbukcvLrWemVwS1JnDG5J6ozBLa2Ad5VoPTC4pSU4v631zOCWpM4Y3JLUGYNbkjqzbHAn2Z7kgSSPJDmW5L2tfnGSg0m+1h4vavUk+VCS+SRHkrx23IOQXgx+MKn1Ypgr7meB91fV5cBVwE1JLgduBg5V1U7gUNsGeAuLv+6+E9gL3LHmXUvSFFs2uKvqVFV9sa3/AHgU2ArsBva3w/YDb2vru4GP1KLPAxcm2bLmnUtjstQdJV5taz1Z0Rx3kh3AFcCDwOaqOtV2fRvY3Na3Ao8PnHai1c5+rr1J5pLMLSwsrLBtSZpeQwd3kpcDnwDeV1XfH9xXVQXUSl64qvZV1WxVzc7MzKzkVGlsvH9bPRgquJOcz2Jof7SqPtnKT5yZAmmPp1v9JLB94PRtrSZJWgPD3FUS4E7g0ar64MCuA8Cetr4HuHeg/s52d8lVwNMDUyqSpBEN8ws4bwB+D/hKksOt9gfAnwD3JLkR+BbwjrbvfuA6YB74EfCuNe1YepH5waTWm2WDu6o+B+Qcu9+0xPEF3DRiX5Kkc/Cbk5LUGYNbaryjRL0wuCWpMwa39AL8YFLrkcEtSZ0xuCWc31ZfDG5J6ozBLUmdMbglqTMGt3QO3lGi9crg1tTzg0n1xuCWpM4Y3JLUGYNbkjpjcEtL8INJrWcGtyR1xuDWVPOOEvXI4JakzgzzY8HbkzyQ5JEkx5K8t9VvTXIyyeG2XDdwzi1J5pM8luS3xzkASZo2w/xY8LPA+6vqi0leATyc5GDbd3tV/e/Bg5NcDlwP/BrwS8A/JvmPVfXcWjYujYsfTGq9W/aKu6pOVdUX2/oPgEeBrS9wym7g7qp6pqq+yeKvvV+5Fs1KklY4x51kB3AF8GArvSfJkSR3Jbmo1bYCjw+cdoIXDnppIpb6YNKrbfVg6OBO8nLgE8D7qur7wB3ArwK7gFPAn63khZPsTTKXZG5hYWElp0rSVBsquJOcz2Jof7SqPglQVU9U1XNV9WPgr/jJdMhJYPvA6dta7adU1b6qmq2q2ZmZmVHGIElTZZi7SgLcCTxaVR8cqG8ZOOx3gaNt/QBwfZILklwG7AQeWruWJWm6DXNXyRuA3wO+kuRwq/0BcEOSXUABx4F3A1TVsST3AI+weEfKTd5RIklrZ9ngrqrPAVli1/0vcM5twG0j9CWNlR9Mqmd+c1KSOmNwa+r490nUO4NbkjpjcEtSZwxuSeqMwS3hHSXqi8GtqeIHk9oIDG5J6ozBLUmdMbglqTMGt6aeH0yqNwa3JHXG4NbU8I4SbRQGt7qVZEXLKM8jrScGtyR1ZpgfUpA2hPtO7f2p7bdu2cfsu/dNqBtp9bzi1tQ6O8ilXhjcmgq33jo36RakNTPMjwW/NMlDSb6c5FiSD7T6ZUkeTDKf5ONJXtLqF7Tt+bZ/x3iHIC3vrVucEtHGMcwV9zPANVX1GmAXcG2Sq4A/BW6vqlcBTwI3tuNvBJ5s9dvbcdK6Y5irV8P8WHABP2yb57elgGuA/9rq+4FbgTuA3W0d4O+B/5ck7XmkiVj8EPKng/rWiXQijW6oOe4km5IcBk4DB4GvA09V1bPtkBPA1ra+FXgcoO1/GnjlWjYtSdNsqOCuqueqahewDbgSePWoL5xkb5K5JHMLCwujPp0kTY0V3VVSVU8BDwCvBy5McmaqZRtwsq2fBLYDtP2/AHx3iefaV1WzVTU7MzOzyvYlafoMc1fJTJIL2/rLgDcDj7IY4G9vh+0B7m3rB9o2bf9nnd+WpLUzzDcntwD7k2xiMejvqar7kjwC3J3kj4EvAXe24+8E/ibJPPA94Pox9C1JU2uYu0qOAFcsUf8Gi/PdZ9f/Bfgva9KdJOln+M1JSeqMwS1JnTG4Jakz/llXdcublTStvOKWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0Z5seCX5rkoSRfTnIsyQda/cNJvpnkcFt2tXqSfCjJfJIjSV477kFI0jQZ5u9xPwNcU1U/THI+8Lkk/9D2/feq+vuzjn8LsLMtrwPuaI+SpDWw7BV3Lfph2zy/LS/0F+x3Ax9p530euDDJltFblSTBkHPcSTYlOQycBg5W1YNt121tOuT2JBe02lbg8YHTT7SaJGkNDBXcVfVcVe0CtgFXJvlPwC3Aq4HfAC4G/udKXjjJ3iRzSeYWFhZW2LYkTa8V3VVSVU8BDwDXVtWpNh3yDPDXwJXtsJPA9oHTtrXa2c+1r6pmq2p2ZmZmdd1L0hQa5q6SmSQXtvWXAW8Gvnpm3jpJgLcBR9spB4B3trtLrgKerqpTY+lekqbQMHeVbAH2J9nEYtDfU1X3JflskhkgwGHg99vx9wPXAfPAj4B3rX3bkjS9lg3uqjoCXLFE/ZpzHF/ATaO3Jklait+clKTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnUlVTboHkvwAeGzSfYzJJcB3Jt3EGGzUccHGHZvj6ssvV9XMUjvOe7E7OYfHqmp20k2MQ5K5jTi2jTou2Lhjc1wbh1MlktQZg1uSOrNegnvfpBsYo406to06Lti4Y3NcG8S6+HBSkjS89XLFLUka0sSDO8m1SR5LMp/k5kn3s1JJ7kpyOsnRgdrFSQ4m+Vp7vKjVk+RDbaxHkrx2cp2/sCTbkzyQ5JEkx5K8t9W7HluSlyZ5KMmX27g+0OqXJXmw9f/xJC9p9Qva9nzbv2OS/S8nyaYkX0pyX9veKOM6nuQrSQ4nmWu1rt+Lo5hocCfZBPw58BbgcuCGJJdPsqdV+DBw7Vm1m4FDVbUTONS2YXGcO9uyF7jjRepxNZ4F3l9VlwNXATe1fza9j+0Z4Jqqeg2wC7g2yVXAnwK3V9WrgCeBG9vxNwJPtvrt7bj17L3AowPbG2VcAL9ZVbsGbv3r/b24elU1sQV4PfDpge1bgFsm2dMqx7EDODqw/Riwpa1vYfE+dYC/BG5Y6rj1vgD3Am/eSGMD/gPwReB1LH6B47xWf/59CXwaeH1bP68dl0n3fo7xbGMxwK4B7gOyEcbVejwOXHJWbcO8F1e6THqqZCvw+MD2iVbr3eaqOtXWvw1sbutdjrf9b/QVwINsgLG16YTDwGngIPB14KmqerYdMtj78+Nq+58GXvnidjy0/wP8D+DHbfuVbIxxARTwmSQPJ9nbat2/F1drvXxzcsOqqkrS7a07SV4OfAJ4X1V9P8nz+3odW1U9B+xKciHwKeDVE25pZEneCpyuqoeTXD3pfsbgjVV1MskvAgeTfHVwZ6/vxdWa9BX3SWD7wPa2VuvdE0m2ALTH063e1XiTnM9iaH+0qj7ZyhtibABV9RTwAItTCBcmOXMhM9j78+Nq+38B+O6L3Oow3gD8TpLjwN0sTpf8X/ofFwBVdbI9nmbxP7ZXsoHeiys16eD+ArCzffL9EuB64MCEe1oLB4A9bX0Pi/PDZ+rvbJ96XwU8PfC/eutKFi+t7wQeraoPDuzqemxJZtqVNklexuK8/aMsBvjb22Fnj+vMeN8OfLbaxOl6UlW3VNW2qtrB4r9Hn62q/0bn4wJI8vNJXnFmHfgt4CidvxdHMulJduA64J9ZnGf8X5PuZxX9fww4Bfwbi3NpN7I4V3gI+Brwj8DF7diweBfN14GvALOT7v8FxvVGFucVjwCH23Jd72MDfh34UhvXUeAPW/1XgIeAeeDvgAta/aVte77t/5VJj2GIMV4N3LdRxtXG8OW2HDuTE72/F0dZ/OakJHVm0lMlkqQVMrglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSerMvwOiKw6A04ym4wAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "dqn.test(env, nb_episodes=5, callbacks=[Render()], visualize=False)"
    ]
@@ -609,7 +701,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -631,7 +723,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -652,35 +744,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Model: \"model_5\"\n",
       "_________________________________________________________________\n",
       "Layer (type)                 Output Shape              Param #   \n",
       "=================================================================\n",
-      "input_3 (InputLayer)         (None, 1, 4)              0         \n",
+      "input_2 (InputLayer)         (None, 1, 4)              0         \n",
       "_________________________________________________________________\n",
-      "flatten_3 (Flatten)          (None, 4)                 0         \n",
+      "flatten_2 (Flatten)          (None, 4)                 0         \n",
       "_________________________________________________________________\n",
-      "dense_12 (Dense)             (None, 16)                80        \n",
+      "dense_6 (Dense)              (None, 16)                80        \n",
       "_________________________________________________________________\n",
-      "activation_9 (Activation)    (None, 16)                0         \n",
+      "activation_5 (Activation)    (None, 16)                0         \n",
       "_________________________________________________________________\n",
-      "dense_13 (Dense)             (None, 16)                272       \n",
+      "dense_7 (Dense)              (None, 16)                272       \n",
       "_________________________________________________________________\n",
-      "activation_10 (Activation)   (None, 16)                0         \n",
+      "activation_6 (Activation)    (None, 16)                0         \n",
       "_________________________________________________________________\n",
-      "dense_14 (Dense)             (None, 16)                272       \n",
+      "dense_8 (Dense)              (None, 16)                272       \n",
       "_________________________________________________________________\n",
-      "activation_11 (Activation)   (None, 16)                0         \n",
+      "activation_7 (Activation)    (None, 16)                0         \n",
       "_________________________________________________________________\n",
-      "dense_15 (Dense)             (None, 2)                 34        \n",
+      "dense_9 (Dense)              (None, 2)                 34        \n",
       "_________________________________________________________________\n",
-      "activation_12 (Activation)   (None, 2)                 0         \n",
+      "activation_8 (Activation)    (None, 2)                 0         \n",
       "=================================================================\n",
       "Total params: 658\n",
       "Trainable params: 658\n",
@@ -713,7 +806,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -733,29 +826,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {},
+   "execution_count": 17,
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   18/10000 [..............................] - ETA: 26:49 - reward: 1.0000done, took 3.035 seconds\n"
+      "  908/10000 [=>............................] - ETA: 32:33 - reward: 1.0000done, took 195.229 seconds\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<keras.callbacks.History at 0x7fc3b9d8b810>"
+       "<keras.callbacks.callbacks.History at 0x7f5f61e3d940>"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXgAAAD8CAYAAAB9y7/cAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAEpFJREFUeJzt3WGMnVed3/Hvr3ZIKNB1QqaWazt1dtcqylbFSafBEajKBrHrpLt1VtqipNUSoUhDpSCBFrWbbKUCUiPtvljSonaj9W6ymIoS0gCNG6XLpibSal+QMIAxdkyWAYxs14kHSAIUNa3Dvy/mGO5Oxp47c2c8vsffj3R1n+c853nuOfbVb54595y5qSokSf35G2vdAEnS6jDgJalTBrwkdcqAl6ROGfCS1CkDXpI6tWoBn2RXkmeTzCS5e7VeR5K0sKzGPPgk64C/At4BHAe+CNxeVc+s+ItJkha0Wnfw1wMzVfWtqvq/wEPA7lV6LUnSAtav0nU3A8cG9o8Dbzlb5SuvvLK2bdu2Sk2RpPFz9OhRvvvd72aUa6xWwC8qyRQwBXDVVVcxPT29Vk2RpAvO5OTkyNdYrSGaE8DWgf0treynqmpPVU1W1eTExMQqNUOSLl6rFfBfBLYnuTrJa4DbgH2r9FqSpAWsyhBNVZ1O8l7gc8A64MGqOrwaryVJWtiqjcFX1ePA46t1fUnSubmSVZI6ZcBLUqcMeEnqlAEvSZ0y4CWpUwa8JHXKgJekThnwktQpA16SOmXAS1KnDHhJ6pQBL0mdMuAlqVMGvCR1yoCXpE4Z8JLUKQNekjplwEtSp0b6yr4kR4EfAq8Ap6tqMskVwKeAbcBR4J1V9cJozZQkLdVK3MH/clXtqKrJtn83sL+qtgP7274k6TxbjSGa3cDetr0XuHUVXkOStIhRA76AP0/ypSRTrWxjVZ1s288BG0d8DUnSMow0Bg+8rapOJPnbwBNJvj54sKoqSS10YvuBMAVw1VVXjdgMSdJ8I93BV9WJ9nwK+CxwPfB8kk0A7fnUWc7dU1WTVTU5MTExSjMkSQtYdsAneV2SN5zZBn4FOATsA+5o1e4AHh21kZKkpRtliGYj8NkkZ67zX6rqz5J8EXg4yZ3Ad4B3jt5MSdJSLTvgq+pbwJsXKP8e8PZRGiVJGp0rWSWpUwa8JHXKgJekThnwktQpA16SOmXAS1KnDHhJ6pQBL0mdMuAlqVMGvCR1yoCXpE4Z8JLUKQNekjplwEtSpwx4SeqUAS9JnTLgJalTBrwkdcqAl6ROLRrwSR5McirJoYGyK5I8keQb7fnyVp4kH00yk+RgkutWs/GSpLMb5g7+Y8CueWV3A/urajuwv+0D3Axsb48p4P6VaaYkaakWDfiq+gvg+/OKdwN72/Ze4NaB8o/XnC8AG5JsWqnGSpKGt9wx+I1VdbJtPwdsbNubgWMD9Y63sldJMpVkOsn07OzsMpshSTqbkT9kraoCahnn7amqyaqanJiYGLUZkqR5lhvwz58ZemnPp1r5CWDrQL0trUySdJ4tN+D3AXe07TuARwfK39Vm0+wEXhoYypEknUfrF6uQ5JPAjcCVSY4DHwR+D3g4yZ3Ad4B3tuqPA7cAM8CPgXevQpslSUNYNOCr6vazHHr7AnULuGvURkmSRudKVknqlAEvSZ0y4CWpUwa8JHXKgJekThnwktQpA16SOmXAS1KnDHhJ6pQBL0mdMuAlqVMGvCR1yoCXpE4Z8JLUKQNekjplwEtSpwx4SeqUAS9JnVo04JM8mORUkkMDZR9KciLJgfa4ZeDYPUlmkjyb5FdXq+GSpHMb5g7+Y8CuBcrvq6od7fE4QJJrgNuAX2rn/GGSdSvVWEnS8BYN+Kr6C+D7Q15vN/BQVb1cVd8GZoDrR2ifJGmZRhmDf2+Sg20I5/JWthk4NlDneCt7lSRTSaaTTM/Ozo7QDEnSQpYb8PcDvwDsAE4Cf7DUC1TVnqqarKrJiYmJZTZDknQ2ywr4qnq+ql6pqp8Af8zPhmFOAFsHqm5pZZKk82xZAZ9k08DubwBnZtjsA25LcmmSq4HtwNOjNVGStBzrF6uQ5JPAjcCVSY4DHwRuTLIDKOAo8B6Aqjqc5GHgGeA0cFdVvbI6TZckncuiAV9Vty9Q/MA56t8L3DtKoyRJo3MlqyR1yoCXpE4Z8JLUKQNekjplwEtSpwx4SeqUAS9JnVp0HrzUiy/tec+ryv7h1B+tQUuk88M7eEnqlAEvSZ0y4HVRW2jYRuqFAS9JnTLgJalTBrwuGs6Y0cXGgJekThnwuuj5Qat6ZcBLUqcMeEnq1KIBn2RrkieTPJPkcJL3tfIrkjyR5Bvt+fJWniQfTTKT5GCS61a7E9Kw/KBVF5Nh7uBPAx+oqmuAncBdSa4B7gb2V9V2YH/bB7gZ2N4eU8D9K95qSdKiFg34qjpZVV9u2z8EjgCbgd3A3lZtL3Br294NfLzmfAHYkGTTirdcWkF+0KoeLWkMPsk24FrgKWBjVZ1sh54DNrbtzcCxgdOOt7L515pKMp1kenZ2donNliQtZuiAT/J64NPA+6vqB4PHqqqAWsoLV9WeqpqsqsmJiYmlnCpJGsJQAZ/kEubC/RNV9ZlW/PyZoZf2fKqVnwC2Dpy+pZVJks6jYWbRBHgAOFJVHxk4tA+4o23fATw6UP6uNptmJ/DSwFCOtOacSaOLxTDf6PRW4LeAryU50Mp+F/g94OEkdwLfAd7Zjj0O3ALMAD8G3r2iLZYkDSVzw+dra3Jysqanp9e6GbrI+BV+upBNTk4yPT2dUa7hSlZJ6pQBL0mdMuAlqVMGvCR1yoCXpE4Z8LpoLTRjxr9Jo54Y8JLUKQNekjplwEvzOEyjXhjwktQpA16SOmXA66Lm355Rzwx4SeqUAS8twA9a1QMDXpI6ZcBLUqcMeF30/KBVvTLgJalTw3zp9tYkTyZ5JsnhJO9r5R9KciLJgfa4ZeCce5LMJHk2ya+uZgckSQsb5g7+NPCBqroG2AncleSaduy+qtrRHo8DtGO3Ab8E7AL+MMm6VWi7tKqcSaNxt2jAV9XJqvpy2/4hcATYfI5TdgMPVdXLVfVtYAa4fiUaK0ka3pLG4JNsA64FnmpF701yMMmDSS5vZZuBYwOnHefcPxAkSatg6IBP8nrg08D7q+oHwP3ALwA7gJPAHyzlhZNMJZlOMj07O7uUU6UV50wa9WiogE9yCXPh/omq+gxAVT1fVa9U1U+AP+ZnwzAngK0Dp29pZX9NVe2pqsmqmpyYmBilD5KkBQwziybAA8CRqvrIQPmmgWq/ARxq2/uA25JcmuRqYDvw9Mo1WTp//KBV42z9EHXeCvwW8LUkB1rZ7wK3J9kBFHAUeA9AVR1O8jDwDHMzcO6qqldWuuGSpHNbNOCr6i+BLHDo8XOccy9w7wjtkiSNyJWsUuMHreqNAS9JnTLgJalTBry0CGfSaFwZ8JLUKQNekjplwEsDnEmjnhjwktQpA14agh+0ahwZ8NI8DtOoFwa8JHXKgJeG5DCNxo0BL0mdMuB1UUky1GPU8xe7jnQ+GPDSAibfs2etmyCNbJgv/JAuWv/9f03NKzH4NT68g5fO4tXhLo0XA15agg9+cHqtmyANbZgv3b4sydNJvprkcJIPt/KrkzyVZCbJp5K8ppVf2vZn2vFtq9sF6fz59b/jEI3GxzB38C8DN1XVm4EdwK4kO4HfB+6rql8EXgDubPXvBF5o5fe1etLYMcw17ob50u0CftR2L2mPAm4C/nkr3wt8CLgf2N22AR4B/mOStOtIY2NuJs1fD/kPr01TpGUZagw+ybokB4BTwBPAN4EXq+p0q3Ic2Ny2NwPHANrxl4A3rmSjJUmLGyrgq+qVqtoBbAGuB9406gsnmUoynWR6dnZ21MtJkuZZ0iyaqnoReBK4AdiQ5MwQzxbgRNs+AWwFaMd/DvjeAtfaU1WTVTU5MTGxzOZLks5mmFk0E0k2tO3XAu8AjjAX9L/Zqt0BPNq297V92vHPO/4uSeffMCtZNwF7k6xj7gfCw1X1WJJngIeS/DvgK8ADrf4DwH9OMgN8H7htFdotSVrEMLNoDgLXLlD+LebG4+eX/x/gn61I6yRJy+ZKVknqlAEvSZ0y4CWpU/65YF1UnNCli4l38JLUKQNekjplwEtSpwx4SeqUAS9JnTLgJalTBrwkdcqAl6ROGfCS1CkDXpI6ZcBLUqcMeEnqlAEvSZ0y4CWpU8N86fZlSZ5O8tUkh5N8uJV/LMm3kxxojx2tPEk+mmQmycEk1612JyRJrzbM34N/Gbipqn6U5BLgL5P8j3bsX1XVI/Pq3wxsb4+3APe3Z0nSebToHXzN+VHbvaQ9zvWtCbuBj7fzvgBsSLJp9KZKkpZiqDH4JOuSHABOAU9U1VPt0L1tGOa+JJe2ss3AsYHTj7cySdJ5NFTAV9UrVbUD2AJcn+TvA/cAbwL+EXAF8DtLeeEkU0mmk0zPzs4usdmSpMUsaRZNVb0IPAnsqqqTbRjmZeBPgetbtRPA1oHTtrSy+dfaU1WTVTU5MTGxvNZLks5qmFk0E0k2tO3XAu8Avn5mXD1JgFuBQ+2UfcC72myancBLVXVyVVovSTqrYWbRbAL2JlnH3A+Eh6vqsSSfTzIBBDgA/MtW/3HgFmAG+DHw7pVvtiRpMYsGfFUdBK5doPyms9Qv4K7RmyZJGoUrWSWpUwa8JHXKgJekThnwktQpA16SOmXAS1KnDHhJ6pQBL0mdMuAlqVMGvCR1yoCXpE4Z8JLUKQNekjplwEtSpwx4SeqUAS9JnTLgJalTBrwkdcqAl6RODR3wSdYl+UqSx9r+1UmeSjKT5FNJXtPKL237M+34ttVpuiTpXJZyB/8+4MjA/u8D91XVLwIvAHe28juBF1r5fa2eJOk8Gyrgk2wB/gnwJ20/wE3AI63KXuDWtr277dOOv73VlySdR+uHrPfvgX8NvKHtvxF4sapOt/3jwOa2vRk4BlBVp5O81Op/d/CCSaaAqbb7cpJDy+rBhe9K5vW9E732C/rtm/0aL383yVRV7VnuBRYN+CS/Bpyqqi8luXG5LzRfa/Se9hrTVTW5Ute+kPTat177Bf32zX6NnyTTtJxcjmHu4N8K/NMktwCXAX8L+A/AhiTr2138FuBEq38C2AocT7Ie+Dnge8ttoCRpeRYdg6+qe6pqS1VtA24DPl9V/wJ4EvjNVu0O4NG2va/t045/vqpqRVstSVrUKPPgfwf47SQzzI2xP9DKHwDe2Mp/G7h7iGst+1eQMdBr33rtF/TbN/s1fkbqW7y5lqQ+uZJVkjq15gGfZFeSZ9vK12GGcy4oSR5McmpwmmeSK5I8keQb7fnyVp4kH219PZjkurVr+bkl2ZrkySTPJDmc5H2tfKz7luSyJE8n+Wrr14dbeRcrs3tdcZ7kaJKvJTnQZpaM/XsRIMmGJI8k+XqSI0luWMl+rWnAJ1kH/CfgZuAa4PYk16xlm5bhY8CueWV3A/urajuwn599DnEzsL09poD7z1Mbl+M08IGqugbYCdzV/m/GvW8vAzdV1ZuBHcCuJDvpZ2V2zyvOf7mqdgxMiRz39yLMzUj8s6p6E/Bm5v7vVq5fVbVmD+AG4HMD+/cA96xlm5bZj23AoYH9Z4FNbXsT8Gzb/iPg9oXqXegP5mZJvaOnvgF/E/gy8BbmFsqsb+U/fV8CnwNuaNvrW72sddvP0p8tLRBuAh4D0kO/WhuPAlfOKxvr9yJzU8i/Pf/ffSX7tdZDND9d9doMrogdZxur6mTbfg7Y2LbHsr/t1/drgafooG9tGOMAcAp4AvgmQ67MBs6szL4QnVlx/pO2P/SKcy7sfgEU8OdJvtRWwcP4vxevBmaBP23Dan+S5HWsYL/WOuC7V3M/asd2qlKS1wOfBt5fVT8YPDaufauqV6pqB3N3vNcDb1rjJo0sAyvO17otq+RtVXUdc8MUdyX5x4MHx/S9uB64Dri/qq4F/jfzppWP2q+1Dvgzq17PGFwRO86eT7IJoD2fauVj1d8klzAX7p+oqs+04i76BlBVLzK3YO8G2srsdmihldlc4Cuzz6w4Pwo8xNwwzU9XnLc649gvAKrqRHs+BXyWuR/M4/5ePA4cr6qn2v4jzAX+ivVrrQP+i8D29kn/a5hbKbtvjdu0EgZX885f5fuu9mn4TuClgV/FLihJwtyitSNV9ZGBQ2PdtyQTSTa07dcy97nCEcZ8ZXZ1vOI8yeuSvOHMNvArwCHG/L1YVc8Bx5L8vVb0duAZVrJfF8AHDbcAf8XcOOi/Wev2LKP9nwROAv+PuZ/IdzI3lrkf+AbwP4ErWt0wN2vom8DXgMm1bv85+vU25n41PAgcaI9bxr1vwD8AvtL6dQj4t63854GngRngvwKXtvLL2v5MO/7za92HIfp4I/BYL/1qffhqexw+kxPj/l5sbd0BTLf3438DLl/JfrmSVZI6tdZDNJKkVWLAS1KnDHhJ6pQBL0mdMuAlqVMGvCR1yoCXpE4Z8JLUqf8PXaCdPKN6foIAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAW4AAAD8CAYAAABXe05zAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAARQ0lEQVR4nO3df6zddX3H8edrBcGpGSDXpmvLitrF4DKLu0OM/oEYFYhZMXEGtkhjSMoSTDQx28AlU5ORaDJlI9uINTDr4kTmj9AQNq2VxPiHwAVrbUHkqjW0qfSqgBgzNvC9P+6neFZa7rk/Drefe56P5Jvz/b6/3+857084vPjyud9zTqoKSVI/fmu5G5AkzY/BLUmdMbglqTMGtyR1xuCWpM4Y3JLUmZEFd5KLkjyYZDrJNaN6HUkaNxnFfdxJVgHfB94CHADuAS6vqvuX/MUkacyM6or7PGC6qn5YVf8D3AJsHtFrSdJYOWlEz7sWeHhg+wDwuuMdfOaZZ9aGDRtG1Iok9Wf//v389Kc/zbH2jSq455RkK7AV4KyzzmJqamq5WpGkE87k5ORx941qquQgsH5ge12rPaOqtlXVZFVNTkxMjKgNSVp5RhXc9wAbk5yd5AXAZcCOEb2WJI2VkUyVVNVTSd4LfAVYBdxcVftG8VqSNG5GNsddVXcAd4zq+SVpXPnJSUnqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnVnUT5cl2Q88ATwNPFVVk0nOAD4PbAD2A++qqkcX16Yk6YiluOJ+U1VtqqrJtn0NsKuqNgK72rYkaYmMYqpkM7C9rW8HLh3Ba0jS2FpscBfw1ST3Jtnaaqur6lBb/wmwepGvIUkasKg5buCNVXUwycuAnUm+N7izqipJHevEFvRbAc4666xFtiFJ42NRV9xVdbA9Hga+DJwHPJJkDUB7PHycc7dV1WRVTU5MTCymDUkaKwsO7iQvSvKSI+vAW4G9wA5gSztsC3DbYpuUJP3GYqZKVgNfTnLkef69qv4ryT3ArUmuBH4MvGvxbUqSjlhwcFfVD4HXHKP+M+DNi2lKknR8fnJSkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6sycwZ3k5iSHk+wdqJ2RZGeSh9rj6a2eJDckmU6yJ8lrR9m8JI2jYa64Pw1cdFTtGmBXVW0EdrVtgIuBjW3ZCty4NG1Kko6YM7ir6hvAz48qbwa2t/XtwKUD9c/UrG8BpyVZs1TNSpIWPse9uqoOtfWfAKvb+lrg4YHjDrTasyTZmmQqydTMzMwC25Ck8bPoP05WVQG1gPO2VdVkVU1OTEwstg1JGhsLDe5HjkyBtMfDrX4QWD9w3LpWkyQtkYUG9w5gS1vfAtw2UL+i3V1yPvD4wJSKJGkJnDTXAUk+B1wAnJnkAPAh4KPArUmuBH4MvKsdfgdwCTAN/Ap4zwh6lqSxNmdwV9Xlx9n15mMcW8DVi21KknR8fnJSkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1Jn5gzuJDcnOZxk70Dtw0kOJtndlksG9l2bZDrJg0neNqrGJWlcDXPF/WngomPUr6+qTW25AyDJOcBlwKvbOf+SZNVSNStJGiK4q+obwM+HfL7NwC1V9WRV/YjZX3s/bxH9SZKOspg57vcm2dOmUk5vtbXAwwPHHGi1Z0myNclUkqmZmZlFtCFJ42WhwX0j8ApgE3AI+Ph8n6CqtlXVZFVNTkxMLLANSRo/Cwruqnqkqp6uql8Dn+I30yEHgfUDh65rNUnSEllQcCdZM7D5DuDIHSc7gMuSnJLkbGAjcPfiWpQkDTpprgOSfA64ADgzyQHgQ8AFSTYBBewHrgKoqn1JbgXuB54Crq6qp0fTuiSNpzmDu6ouP0b5puc4/jrgusU0JUk6Pj85KUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjoz5+2A0ji5d9tVz6r90dZPLkMn0vF5xS1JnTG4JakzBrfUHGuaRDoRGdyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzswZ3EnWJ7kzyf1J9iV5X6ufkWRnkofa4+mtniQ3JJlOsifJa0c9CGlU/J4SnYiGueJ+CvhAVZ0DnA9cneQc4BpgV1VtBHa1bYCLmf11943AVuDGJe9aksbYnMFdVYeq6r62/gTwALAW2Axsb4dtBy5t65uBz9SsbwGnJVmz5J1L0pia1xx3kg3AucBdwOqqOtR2/QRY3dbXAg8PnHag1Y5+rq1JppJMzczMzLNtSRpfQwd3khcDXwTeX1W/GNxXVQXUfF64qrZV1WRVTU5MTMznVEkaa0MFd5KTmQ3tz1bVl1r5kSNTIO3xcKsfBNYPnL6u1SRJS2CYu0oC3AQ8UFWfGNi1A9jS1rcAtw3Ur2h3l5wPPD4wpSJJWqRhfrrsDcC7ge8m2d1qHwQ+Ctya5Ergx8C72r47gEuAaeBXwHuWtGNpBPwubvVkzuCuqm8COc7uNx/j+AKuXmRfkqTj8JOTktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWjsPv4taJyuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrfGnj+ioN4Y3JLUGYNbkjozzI8Fr09yZ5L7k+xL8r5W/3CSg0l2t+WSgXOuTTKd5MEkbxvlACRp3AzzY8FPAR+oqvuSvAS4N8nOtu/6qvr7wYOTnANcBrwa+F3ga0l+v6qeXsrGJWlczXnFXVWHquq+tv4E8ACw9jlO2QzcUlVPVtWPmP219/OWollJ0jznuJNsAM4F7mql9ybZk+TmJKe32lrg4YHTDvDcQS9JmoehgzvJi4EvAu+vql8ANwKvADYBh4CPz+eFk2xNMpVkamZmZj6nStJYGyq4k5zMbGh/tqq+BFBVj1TV01X1a+BT/GY65CCwfuD0da32/1TVtqqarKrJiYmJxYxBWnJ+F7dOZMPcVRLgJuCBqvrEQH3NwGHvAPa29R3AZUlOSXI2sBG4e+lalqTxNsxdJW8A3g18N8nuVvsgcHmSTUAB+4GrAKpqX5JbgfuZvSPlau8okaSlM2dwV9U3gRxj1x3Pcc51wHWL6EuSdBx+clKSOmNwS1JnDG5J6ozBLUmdMbg11vwubvXI4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGt3QUv4tbJzqDWytOkqGXUZwvjZrBLUmdGeaHFKQV7fZDW59Zf/uabcvYiTQcr7g11gZDW+qFwS0NMMjVg2F+LPjUJHcn+U6SfUk+0upnJ7kryXSSzyd5Qauf0ran2/4Nox2CtHScKlEPhrnifhK4sKpeA2wCLkpyPvAx4PqqeiXwKHBlO/5K4NFWv74dJ52QDGr1aJgfCy7gl23z5LYUcCHwZ62+HfgwcCOwua0DfAH4pyRpzyOdUCav2gb8Jrw/vGydSMMbao47yaoku4HDwE7gB8BjVfVUO+QAsLatrwUeBmj7HwdeupRNS9I4Gyq4q+rpqtoErAPOA1612BdOsjXJVJKpmZmZxT6dJI2Ned1VUlWPAXcCrwdOS3JkqmUdcLCtHwTWA7T9vwP87BjPta2qJqtqcmJiYoHtS9L4Geaukokkp7X1FwJvAR5gNsDf2Q7bAtzW1ne0bdr+rzu/LUlLZ5hPTq4BtidZxWzQ31pVtye5H7glyd8B3wZuasffBPxbkmng58BlI+hbksbWMHeV7AHOPUb9h8zOdx9d/2/gT5ekO0nSs/jJSUnqjMEtSZ0xuCWpM36tq1Ycb2LSSucVtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqzDA/FnxqkruTfCfJviQfafVPJ/lRkt1t2dTqSXJDkukke5K8dtSDkKRxMsz3cT8JXFhVv0xyMvDNJP/Z9v1lVX3hqOMvBja25XXAje1RkrQE5rzirlm/bJsnt+W5vql+M/CZdt63gNOSrFl8q5IkGHKOO8mqJLuBw8DOqrqr7bquTYdcn+SUVlsLPDxw+oFWkyQtgaGCu6qerqpNwDrgvCR/AFwLvAr4Y+AM4K/n88JJtiaZSjI1MzMzz7YlaXzN666SqnoMuBO4qKoOtemQJ4F/Bc5rhx0E1g+ctq7Vjn6ubVU1WVWTExMTC+teksbQMHeVTCQ5ra2/EHgL8L0j89ZJAlwK7G2n7ACuaHeXnA88XlWHRtK9JI2hYe4qWQNsT7KK2aC/tapuT/L1JBNAgN3AX7Tj7wAuAaaBXwHvWfq2JWl8zRncVbUHOPcY9QuPc3wBVy++NUnSsfjJSUnqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1JlU1XL3QJIngAeXu48RORP46XI3MQIrdVywcsfmuPrye1U1cawdJz3fnRzHg1U1udxNjEKSqZU4tpU6Lli5Y3NcK4dTJZLUGYNbkjpzogT3tuVuYIRW6thW6rhg5Y7Nca0QJ8QfJyVJwztRrrglSUNa9uBOclGSB5NMJ7lmufuZryQ3JzmcZO9A7YwkO5M81B5Pb/UkuaGNdU+S1y5f588tyfokdya5P8m+JO9r9a7HluTUJHcn+U4b10da/ewkd7X+P5/kBa1+Stuebvs3LGf/c0myKsm3k9zetlfKuPYn+W6S3UmmWq3r9+JiLGtwJ1kF/DNwMXAOcHmSc5azpwX4NHDRUbVrgF1VtRHY1bZhdpwb27IVuPF56nEhngI+UFXnAOcDV7d/Nr2P7Ungwqp6DbAJuCjJ+cDHgOur6pXAo8CV7fgrgUdb/fp23InsfcADA9srZVwAb6qqTQO3/vX+Xly4qlq2BXg98JWB7WuBa5ezpwWOYwOwd2D7QWBNW1/D7H3qAJ8ELj/WcSf6AtwGvGUljQ34beA+4HXMfoDjpFZ/5n0JfAV4fVs/qR2X5e79OONZx2yAXQjcDmQljKv1uB8486jainkvzndZ7qmStcDDA9sHWq13q6vqUFv/CbC6rXc53va/0ecCd7ECxtamE3YDh4GdwA+Ax6rqqXbIYO/PjKvtfxx46fPb8dD+Afgr4Ndt+6WsjHEBFPDVJPcm2dpq3b8XF+pE+eTkilVVlaTbW3eSvBj4IvD+qvpFkmf29Tq2qnoa2JTkNODLwKuWuaVFS/J24HBV3ZvkguXuZwTeWFUHk7wM2Jnke4M7e30vLtRyX3EfBNYPbK9rtd49kmQNQHs83OpdjTfJycyG9mer6kutvCLGBlBVjwF3MjuFcFqSIxcyg70/M662/3eAnz3PrQ7jDcCfJNkP3MLsdMk/0v+4AKiqg+3xMLP/sT2PFfRenK/lDu57gI3tL98vAC4DdixzT0thB7ClrW9hdn74SP2K9lfv84HHB/5X74SS2Uvrm4AHquoTA7u6HluSiXalTZIXMjtv/wCzAf7OdtjR4zoy3ncCX682cXoiqaprq2pdVW1g9t+jr1fVn9P5uACSvCjJS46sA28F9tL5e3FRlnuSHbgE+D6z84x/s9z9LKD/zwGHgP9ldi7tSmbnCncBDwFfA85ox4bZu2h+AHwXmFzu/p9jXG9kdl5xD7C7LZf0PjbgD4Fvt3HtBf621V8O3A1MA/8BnNLqp7bt6bb/5cs9hiHGeAFw+0oZVxvDd9qy70hO9P5eXMziJyclqTPLPVUiSZong1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM78HzQ/8dha3MVlAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -768,7 +863,7 @@
    ],
    "source": [
     "# nb_steps represents the number of steps, you can try and change it\n",
-    "dqn.fit(env, callbacks=[Render()], nb_steps=1000, log_interval=10000)"
+    "sarsa.fit(env, callbacks=[Render()], nb_steps=1000, log_interval=10000)"
    ]
   },
   {
@@ -797,7 +892,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -813,11 +908,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Episode 5: reward: 12.000, steps: 12\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<keras.callbacks.callbacks.History at 0x7f5f6062b4a8>"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAW4AAAD8CAYAAABXe05zAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAARm0lEQVR4nO3df6zddX3H8edrBdFNM0CuTdeWlW1dDFtmcXeI0T8Qo0NiVpc4A1tmY0jKEkw0MdvAJZsmI9mSKZvZRqyBWRcnMn+EhrC5rpIs/iF40VpbkHnVGtpUelVAjRkb+N4f51M41pZ77o/D7eec5yM5Od/v+/v9nvP+hMOLL5/v99yTqkKS1I+fWesGJElLY3BLUmcMbknqjMEtSZ0xuCWpMwa3JHVmbMGd5MokDyWZT3LDuN5HkqZNxnEfd5J1wH8DrwOOAF8ArqmqB1b9zSRpyozrjPtSYL6qvlFV/wvcDmwf03tJ0lQ5a0yvuxF4eGj9CPCK0+18wQUX1JYtW8bUiiT15/Dhw3znO9/JqbaNK7gXlWQnsBPgwgsvZG5ubq1akaQzzuzs7Gm3jWuq5CiweWh9U6s9rap2VdVsVc3OzMyMqQ1JmjzjCu4vAFuTXJTkecDVwJ4xvZckTZWxTJVU1ZNJ3g58BlgH3FZVh8bxXpI0bcY2x11VdwN3j+v1JWla+c1JSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdWdFPlyU5DPwAeAp4sqpmk5wPfBzYAhwG3lJVj66sTUnSCatxxv2aqtpWVbNt/QZgX1VtBfa1dUnSKhnHVMl2YHdb3g28aQzvIUlTa6XBXcB/JLk/yc5WW19Vx9ryt4H1K3wPSdKQFc1xA6+uqqNJXgLsTfLV4Y1VVUnqVAe2oN8JcOGFF66wDUmaHis6466qo+35OPBp4FLgkSQbANrz8dMcu6uqZqtqdmZmZiVtSNJUWXZwJ/m5JC86sQy8HjgI7AF2tN12AHeutElJ0jNWMlWyHvh0khOv8y9V9e9JvgDckeRa4FvAW1bepiTphGUHd1V9A3jZKerfBV67kqYkSafnNyclqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4Jakziwa3EluS3I8ycGh2vlJ9ib5Wns+r9WT5ANJ5pMcSPLycTYvSdNolDPuDwNXnlS7AdhXVVuBfW0d4A3A1vbYCdyyOm1Kkk5YNLir6r+A751U3g7sbsu7gTcN1T9SA58Hzk2yYbWalSQtf457fVUda8vfBta35Y3Aw0P7HWm1n5JkZ5K5JHMLCwvLbEOSps+KL05WVQG1jON2VdVsVc3OzMystA1JmhrLDe5HTkyBtOfjrX4U2Dy036ZWkyStkuUG9x5gR1veAdw5VH9ru7vkMuDxoSkVSdIqOGuxHZJ8DLgcuCDJEeAvgL8C7khyLfAt4C1t97uBq4B54EfA28bQsyRNtUWDu6quOc2m155i3wKuX2lTkqTT85uTktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6s2hwJ7ktyfEkB4dq70lyNMn+9rhqaNuNSeaTPJTkt8fVuCRNq1HOuD8MXHmK+s1Vta097gZIcjFwNfBr7Zh/TLJutZqVJI0Q3FX1X8D3Rny97cDtVfVEVX2Twa+9X7qC/iRJJ1nJHPfbkxxoUynntdpG4OGhfY602k9JsjPJXJK5hYWFFbQhSdNlucF9C/DLwDbgGPC+pb5AVe2qqtmqmp2ZmVlmG5I0fZYV3FX1SFU9VVU/Bj7EM9MhR4HNQ7tuajVJ0ipZVnAn2TC0+rvAiTtO9gBXJzknyUXAVuC+lbUoSRp21mI7JPkYcDlwQZIjwF8AlyfZBhRwGLgOoKoOJbkDeAB4Eri+qp4aT+uSNJ0WDe6quuYU5VufZf+bgJtW0pQk6fT85qQkdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ1Z9D5uaZrcv+u6p5d/c+cH17AT6fQ845ZO4/5d1/1EkEtnCoNbagxp9cLglqTOGNyS1BmDW3oWXqDUmcjglqTOGNwSXphUXwxuSeqMwS1JnTG4pdPwwqTOVIsGd5LNSe5J8kCSQ0ne0ernJ9mb5Gvt+bxWT5IPJJlPciDJy8c9CEmaJqOccT8JvKuqLgYuA65PcjFwA7CvqrYC+9o6wBsY/Lr7VmAncMuqdy2tIi9MqjeLBndVHauqL7blHwAPAhuB7cDutttu4E1teTvwkRr4PHBukg2r3rkkTaklzXEn2QJcAtwLrK+qY23Tt4H1bXkj8PDQYUda7eTX2plkLsncwsLCEtuWpOk1cnAneSHwSeCdVfX94W1VVUAt5Y2raldVzVbV7MzMzFIOlcbOC5M6k40U3EnOZhDaH62qT7XyIyemQNrz8VY/CmweOnxTq0mSVsEod5UEuBV4sKreP7RpD7CjLe8A7hyqv7XdXXIZ8PjQlIp0RvHCpHo0yi/gvAr4Q+ArSfa32ruBvwLuSHIt8C3gLW3b3cBVwDzwI+Btq9qxJE25RYO7qj4H5DSbX3uK/Qu4foV9SWvG+W2d6fzmpCR1xuCWpM4Y3Jpap7ow6TSJemBwS1JnDG5J6ozBLUmdMbglqTMGt6aSFybVM4NbkjpjcGvq+PdJ1DuDW5I6Y3BLUmcMbgkvTKovBrckdcbg1lTxwqQmgcEtSZ0xuCWpMwa3pp4XJtWbUX4seHOSe5I8kORQkne0+nuSHE2yvz2uGjrmxiTzSR5K8tvjHIAkTZtRfiz4SeBdVfXFJC8C7k+yt227uar+ZnjnJBcDVwO/BvwC8J9JfrWqnlrNxqWl8sKkJsWiZ9xVdayqvtiWfwA8CGx8lkO2A7dX1RNV9U0Gv/Z+6Wo0K0la4hx3ki3AJcC9rfT2JAeS3JbkvFbbCDw8dNgRnj3opTXj/LZ6NHJwJ3kh8EngnVX1feAW4JeBbcAx4H1LeeMkO5PMJZlbWFhYyqGSNNVGCu4kZzMI7Y9W1acAquqRqnqqqn4MfIhnpkOOApuHDt/Uaj+hqnZV1WxVzc7MzKxkDNKinN/WJBnlrpIAtwIPVtX7h+obhnb7XeBgW94DXJ3knCQXAVuB+1avZUmabqPcVfIq4A+BryTZ32rvBq5Jsg0o4DBwHUBVHUpyB/AAgztSrveOEklaPYsGd1V9DsgpNt39LMfcBNy0gr6ksfPCpHrlNyclqTMGtyaeFyY1aQxuSeqMwS1JnTG4NZW8MKmeGdyS1BmDWxPNC5OaRAa3po7TJOqdwa2J5dm2JpXBLUmdMbglqTMGtyR1xuDWVPHCpCbBKH/WVTojDP40/GjmPrhzRa9RVSO/l/Rc84xbkjrjGbcm1l3HnjnrfuOGXWvYibS6POPWRBoO7VOtSz0zuDU1Zq/zrFuTYZQfC35+kvuSfDnJoSTvbfWLktybZD7Jx5M8r9XPaevzbfuW8Q5B+kmnuzApTYpRzrifAK6oqpcB24Ark1wG/DVwc1X9CvAocG3b/1rg0Va/ue0nPWdmr9v1U3PaznFrkozyY8EF/LCtnt0eBVwB/H6r7wbeA9wCbG/LAJ8A/j5Jyvur9BwaTIs8E9bvWbNOpNU30hx3knVJ9gPHgb3A14HHqurJtssRYGNb3gg8DNC2Pw68eDWblqRpNlJwV9VTVbUN2ARcCrx0pW+cZGeSuSRzCwsLK305SZoaS7qrpKoeA+4BXgmcm+TEVMsm4GhbPgpsBmjbfx747ilea1dVzVbV7MzMzDLbl6TpM8pdJTNJzm3LLwBeBzzIIMDf3HbbAdzZlve0ddr2zzq/LUmrZ5RvTm4AdidZxyDo76iqu5I8ANye5C+BLwG3tv1vBf45yTzwPeDqMfQtSVNrlLtKDgCXnKL+DQbz3SfX/wf4vVXpTpL0U/zmpCR1xuCWpM4Y3JLUGf+sq7rhzUnSgGfcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4Jakzo/xY8POT3Jfky0kOJXlvq384yTeT7G+Pba2eJB9IMp/kQJKXj3sQkjRNRvl73E8AV1TVD5OcDXwuyb+1bX9cVZ84af83AFvb4xXALe1ZkrQKFj3jroEfttWz2+PZ/qL9duAj7bjPA+cm2bDyViVJMOIcd5J1SfYDx4G9VXVv23RTmw65Ock5rbYReHjo8COtJklaBSMFd1U9VVXbgE3ApUl+HbgReCnwW8D5wJ8u5Y2T7Ewyl2RuYWFhiW1L0vRa0l0lVfUYcA9wZVUda9MhTwD/BFzadjsKbB46bFOrnfxau6pqtqpmZ2Zmlte9JE2hUe4qmUlyblt+AfA64Ksn5q2TBHgTcLAdsgd4a7u75DLg8ao6NpbuJWkKjXJXyQZgd5J1DIL+jqq6K8lnk8wAAfYDf9T2vxu4CpgHfgS8bfXblqTptWhwV9UB4JJT1K84zf4FXL/y1iRJp+I3JyWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmdSVWvdA0l+ADy01n2MyQXAd9a6iTGY1HHB5I7NcfXlF6tq5lQbznquOzmNh6pqdq2bGIckc5M4tkkdF0zu2BzX5HCqRJI6Y3BLUmfOlODetdYNjNGkjm1SxwWTOzbHNSHOiIuTkqTRnSln3JKkEa15cCe5MslDSeaT3LDW/SxVktuSHE9ycKh2fpK9Sb7Wns9r9ST5QBvrgSQvX7vOn12SzUnuSfJAkkNJ3tHqXY8tyfOT3Jfky21c7231i5Lc2/r/eJLntfo5bX2+bd+ylv0vJsm6JF9Kcldbn5RxHU7ylST7k8y1WtefxZVY0+BOsg74B+ANwMXANUkuXsueluHDwJUn1W4A9lXVVmBfW4fBOLe2x07glueox+V4EnhXVV0MXAZc3/7Z9D62J4ArquplwDbgyiSXAX8N3FxVvwI8Clzb9r8WeLTVb277ncneATw4tD4p4wJ4TVVtG7r1r/fP4vJV1Zo9gFcCnxlavxG4cS17WuY4tgAHh9YfAja05Q0M7lMH+CBwzan2O9MfwJ3A6yZpbMDPAl8EXsHgCxxntfrTn0vgM8Ar2/JZbb+sde+nGc8mBgF2BXAXkEkYV+vxMHDBSbWJ+Swu9bHWUyUbgYeH1o+0Wu/WV9WxtvxtYH1b7nK87X+jLwHuZQLG1qYT9gPHgb3A14HHqurJtstw70+Pq21/HHjxc9vxyP4W+BPgx239xUzGuAAK+I8k9yfZ2WrdfxaX60z55uTEqqpK0u2tO0leCHwSeGdVfT/J09t6HVtVPQVsS3Iu8GngpWvc0ooleSNwvKruT3L5WvczBq+uqqNJXgLsTfLV4Y29fhaXa63PuI8Cm4fWN7Va7x5JsgGgPR9v9a7Gm+RsBqH90ar6VCtPxNgAquox4B4GUwjnJjlxIjPc+9Pjatt/Hvjuc9zqKF4F/E6Sw8DtDKZL/o7+xwVAVR1tz8cZ/Mf2Uibos7hUax3cXwC2tivfzwOuBvascU+rYQ+woy3vYDA/fKL+1nbV+zLg8aH/1TujZHBqfSvwYFW9f2hT12NLMtPOtEnyAgbz9g8yCPA3t91OHteJ8b4Z+Gy1idMzSVXdWFWbqmoLg3+PPltVf0Dn4wJI8nNJXnRiGXg9cJDOP4srstaT7MBVwH8zmGf8s7XuZxn9fww4Bvwfg7m0axnMFe4Dvgb8J3B+2zcM7qL5OvAVYHat+3+Wcb2awbziAWB/e1zV+9iA3wC+1MZ1EPjzVv8l4D5gHvhX4JxWf35bn2/bf2mtxzDCGC8H7pqUcbUxfLk9Dp3Iid4/iyt5+M1JSerMWk+VSJKWyOCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4Jakz/w+KwRlGb6MhtAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "dqn.test(env, nb_episodes=5, callbacks=[Render()], visualize=False)"
+    "sarsa.test(env, nb_episodes=5, callbacks=[Render()], visualize=False)"
    ]
   },
   {
@@ -850,21 +975,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
There's a problem when initializing `DQNAgent` (cell #7 in my version) where the agent tries to take the `len` of the `model.output` tensorflow tensor and ends up giving an error about len not working with symbolic tensors. Downgrading to tensorflow 1.13.1 fixes this problem. See the original [keras-rl issue](https://github.com/keras-rl/keras-rl/issues/348)

Also fixed some imports in cell 3 (added `Input` and `Model`), and in the SARSA section changed it to use `sarsa` instead of `dqn`